### PR TITLE
Comment out SMLIB calls, add missing objects, compiler flags

### DIFF
--- a/Makefile.rh64
+++ b/Makefile.rh64
@@ -31,11 +31,13 @@ COMMON =  Atmos.com Dummy.com Equivs.com Factor.com Kappa.com Linex.com \
         Quants.com Multimod.com Dampdat.com Source.com
 
 CC = cc
-FC = f77 -Wall
+#FC = f77 -Wall
+FC = gfortran -fno-range-check -w -fallow-argument-mismatch
 
 # the following lines point to some needed libraries
 X11LIB = /usr/X11R6/lib64
-SMLIB = /opt/local/sm_2.4.27-x86_64/lib
+# commenting out SMLIB  as SuperMongo isn't needed
+#SMLIB = /opt/local/sm_2.4.27-x86_64/lib
 
 #        here are the compilation and linking commands
 all: MOOG ;
@@ -52,8 +54,8 @@ all: MOOG ;
 	@echo -----------------------------------------------------------------
 
 MOOG:  $(OBJECTS);
-	$(FC) $(OBJECTS) -o MOOG -L$(X11LIB) -lX11 \
-        -L$(SMLIB) -lplotsub -ldevices -lutils
+	$(FC) $(OBJECTS) -o MOOG -L$(X11LIB) -lX11 #\
+        #-L$(SMLIB) -lplotsub -ldevices -lutils
 
 $(OBJECTS): $(COMMON)
 

--- a/Makefile.rh64silent
+++ b/Makefile.rh64silent
@@ -3,12 +3,12 @@
 
 #     here are the object files
 OBJECTS = Abfind.o Abpop.o Abunplot.o Batom.o Begin.o Binary.o \
-	Binplot.o Binplotprep.o Blends.o Bmolec.o Boxit.o \
+	Binplot.o Binplotprep.o Blankstring.o Blends.o Bmolec.o Boxit.o \
 	Calmod.o Cdcalc.o Chabund.o Cog.o Cogplot.o Cogsyn.o \
 	Correl.o Crosscorr.o Curve.o Damping.o Defcolor.o Discov.o \
 	Doflux.o Drawcurs.o Eqlib.o Estim.o Ewfind.o \
 	Ewweighted.o Fakeline.o Findtic.o Finish.o \
-	Fluxplot.o Gammabark.o Getasci.o Getcount.o Getnum.o \
+	Fluxplot.o Gammabark.o Getasci.o Getcount.o Getnum.o Getsyns.o \
 	Gridplo.o Gridsyn.o Infile.o Inlines.o Inmodel.o Invert.o \
 	Jexpint.o Lineinfo.o Lineabund.o Linlimit.o \
 	Makeplot.o Minimax.o Molquery.o Moogsilent.o Mydriver.o \
@@ -31,7 +31,8 @@ COMMON =  Atmos.com Dummy.com Equivs.com Factor.com Kappa.com Linex.com \
         Quants.com Multimod.com Dampdat.com Source.com
 
 CC = cc
-FC = f77 -Wall
+#FC = f77 -Wall
+FC = gfortran -fno-range-check -w -fallow-argument-mismatch
 
 # the following lines point to some needed libraries
 X11LIB = /usr/X11R6/lib64
@@ -52,8 +53,9 @@ all: MOOGSILENT ;
 	@echo -----------------------------------------------------------------
 
 MOOGSILENT:  $(OBJECTS);
-	$(FC) $(OBJECTS) -o MOOGSILENT -L$(X11LIB) -lX11 \
-        -L$(SMLIB) -lplotsub -ldevices -lutils
+	$(FC) $(OBJECTS) -o MOOGSILENT
+	#-L$(X11LIB) -lX11 \
+        #-L$(SMLIB) -lplotsub -ldevices -lutils
 
 $(OBJECTS): $(COMMON)
 


### PR DESCRIPTION
Hi Alex,

I saw that people trying to set up SMHR will now be redirected to this repository. There are a few things I had to tweak while setting up on a 64-bit Linux system. Apart from changing compiler flags and commenting out calls to `SMLIB`, there was one additional thing:

`Blankstring.o` and `Getsyns.o` weren't included in the `OBJECTS` list in `Makefile.rh64silent`, which were giving me errors. That must've happened mistakenly, but I've fixed that too.