### PR TITLE
fix: standard rh64 (linux) MOOGSILENT Makefile

### DIFF
--- a/Makefile.rh64silent
+++ b/Makefile.rh64silent
@@ -3,12 +3,12 @@
 
 #     here are the object files
 OBJECTS = Abfind.o Abpop.o Abunplot.o Batom.o Begin.o Binary.o \
-	Binplot.o Binplotprep.o Blends.o Bmolec.o Boxit.o \
+	Binplot.o Binplotprep.o Blankstring.o Blends.o Bmolec.o Boxit.o \
 	Calmod.o Cdcalc.o Chabund.o Cog.o Cogplot.o Cogsyn.o \
 	Correl.o Crosscorr.o Curve.o Damping.o Defcolor.o Discov.o \
 	Doflux.o Drawcurs.o Eqlib.o Estim.o Ewfind.o \
 	Ewweighted.o Fakeline.o Findtic.o Finish.o \
-	Fluxplot.o Gammabark.o Getasci.o Getcount.o Getnum.o \
+	Fluxplot.o Gammabark.o Getasci.o Getcount.o Getnum.o Getsyns.o \
 	Gridplo.o Gridsyn.o Infile.o Inlines.o Inmodel.o Invert.o \
 	Jexpint.o Lineinfo.o Lineabund.o Linlimit.o \
 	Makeplot.o Minimax.o Molquery.o Moogsilent.o Mydriver.o \
@@ -31,11 +31,11 @@ COMMON =  Atmos.com Dummy.com Equivs.com Factor.com Kappa.com Linex.com \
         Quants.com Multimod.com Dampdat.com Source.com
 
 CC = cc
-FC = f77 -Wall
+FC = gfortran -fno-range-check -w -fallow-argument-mismatch -ff2c
 
 # the following lines point to some needed libraries
-X11LIB = /usr/X11R6/lib64
-SMLIB = /opt/local/sm_2.4.27-x86_64/lib
+X11LIB = /etc
+#SMLIB = /opt/local/sm_2.4.27-x86_64/lib
 
 #        here are the compilation and linking commands
 all: MOOGSILENT ;
@@ -52,8 +52,7 @@ all: MOOGSILENT ;
 	@echo -----------------------------------------------------------------
 
 MOOGSILENT:  $(OBJECTS);
-	$(FC) $(OBJECTS) -o MOOGSILENT -L$(X11LIB) -lX11 \
-        -L$(SMLIB) -lplotsub -ldevices -lutils
+	$(FC) $(OBJECTS) -o MOOGSILENT -L$(X11LIB) -lX11
 
 $(OBJECTS): $(COMMON)
 


### PR DESCRIPTION
- no more SuperMongo dependency!
- added missing fortran files to Makefile.rh64silent
- fixed library spec
- uses gfortran now

these changes should make `Makefile.rh64silent` work on more modern Linux distros without SuperMongo as well, which is required for [andycasey/smhr](github.com/andycasey/smhr)